### PR TITLE
Fixes 20. Overwrite splash with same destination.

### DIFF
--- a/src/Core/Nanosplash.ts
+++ b/src/Core/Nanosplash.ts
@@ -71,4 +71,10 @@ export class Nanosplash implements NanosplashInterface {
             })
         }
     }
+
+    public getSplashesWithDestinationNode(node: HTMLElement): SplashInstance[]
+    {
+        const fnSameDestinationNode = (v: SplashInstance) => v.getDestination() === node
+        return Array.from(this.instances.values()).filter(fnSameDestinationNode)
+    }
 }

--- a/src/Core/SplashInstance.ts
+++ b/src/Core/SplashInstance.ts
@@ -1,19 +1,20 @@
 import {Destination} from "../types";
 import {Nanosplash} from "./Nanosplash";
 import {addClass, mk, move, setAttr} from "../utilities/dom";
-import {NanosplashRepository} from "../repositories/NanosplashRepository";
 import {IdentityInterface} from "../Interfaces/IdentityInterface";
+import {NanosplashRepository} from "../repositories/NanosplashRepository";
 
 export class SplashInstance implements IdentityInterface {
     private readonly id: string
     private imgSrc: string | undefined
     private readonly nsInstance: Nanosplash
+    private destinationNode: HTMLElement | undefined
     private readonly nsRootElement: HTMLDivElement = mk('div') as HTMLDivElement
-    private readonly nsWrapperElement: HTMLDivElement = mk('div') as HTMLDivElement
+    private readonly nsTextElement: HTMLDivElement = mk('div') as HTMLDivElement
     private readonly nsWindowElement: HTMLDivElement = mk('div') as HTMLDivElement
+    private readonly nsWrapperElement: HTMLDivElement = mk('div') as HTMLDivElement
     private readonly nsContentElement: HTMLDivElement = mk('div') as HTMLDivElement
     private readonly nsImageElement: HTMLImageElement = mk('img') as HTMLImageElement
-    private readonly nsTextElement: HTMLDivElement = mk('div') as HTMLDivElement
 
     public constructor(ns: Nanosplash, text: string, imgSrc?: string) {
         this.id = Math.random().toString(36).substring(2)
@@ -80,7 +81,12 @@ export class SplashInstance implements IdentityInterface {
         return this
     }
 
-    private cleanup(): void
+    public getDestination(): HTMLElement | undefined
+    {
+        return this.destinationNode
+    }
+
+    private cleanAndRestore(): void
     {
         const currentParent = this.nsRootElement.parentElement
         if (currentParent) {
@@ -110,17 +116,36 @@ export class SplashInstance implements IdentityInterface {
         move(this.nsRootElement, document.body, true)
     }
 
+    private replaceSplashInstancesHavingSameDestination(destinationNode: HTMLElement): void
+    {
+        const fnNotSameInstance = (v: SplashInstance) => v.getId() !== this.getId()
+        const fnDelete = (v: SplashInstance) => v.delete()
+        this.nsInstance.getSplashesWithDestinationNode(destinationNode).filter(fnNotSameInstance).forEach(fnDelete)
+    }
+
     public moveTo(destination: Destination): void
     {
-        this.cleanup()
-        const targetNode = NanosplashRepository.destinationToNode(destination)
-        const targetIsBody = targetNode === document.body
+        // Clean up and restore previous location if any.
+        this.cleanAndRestore()
+
+        // Convert the destination into a DOM Node
+        this.destinationNode = NanosplashRepository.destinationToNode(destination)
+
+        // Replace splash instances having the same destination node
+        this.replaceSplashInstancesHavingSameDestination(this.destinationNode)
+
+        // Assess whether the destination node is the Document body or not
+        const targetIsBody = this.destinationNode === document.body
+
+
         if (targetIsBody) {
             this.moveWithFullscreenStrategy()
         } else {
             this.resetFullscreenAttributes()
-            this.moveWithRegularStrategy(targetNode)
+            this.moveWithRegularStrategy(this.destinationNode)
         }
+
+        // Assemble the Nanosplash component
         this.assembleNSComponent()
     }
 
@@ -147,7 +172,7 @@ export class SplashInstance implements IdentityInterface {
     }
 
     public delete(): void {
-        this.cleanup()
+        this.cleanAndRestore()
         this.removeElementsFromDOM()
         this.nsInstance.delete(this)
     }

--- a/src/repositories/NanosplashRepository.ts
+++ b/src/repositories/NanosplashRepository.ts
@@ -17,7 +17,8 @@ export class NanosplashRepository {
         throw new Error('Destination argument must string or Node')
     }
 
-    public static createContextualApiObject(splash: SplashInstance): ContextualAPIObject {
+    public static createContextualApiObject(splash: SplashInstance): ContextualAPIObject
+    {
         const ctx = {
             getId: () => splash.getId(),
             remove: () => splash.delete(),


### PR DESCRIPTION
Having multiple splash instances residing inside the same node doesn't make sense. This fix makes the latest splash introduced inside a node to replace all other splashes inside the same destination node. This way, each destination node will only have one splash instance.