### PR TITLE
fix: stabilize spinner rotation layer to prevent Chrome wobble

### DIFF
--- a/src/style/ns.css
+++ b/src/style/ns.css
@@ -176,6 +176,9 @@ body.nsh > .ns {
     width: inherit;
     height: inherit;
     stroke-width: 8;
+    transform-origin: 50% 50%;
+    will-change: transform;
+    backface-visibility: hidden;
   }
   & .path {
     stroke: var(--color);
@@ -194,6 +197,9 @@ body.nsh > .ns {
   }
   .nss > svg {
     animation: nsRotate 6s linear infinite;
+    transform-origin: 50% 50%;
+    will-change: transform;
+    backface-visibility: hidden;
   }
   .nss .path {
     animation: none;


### PR DESCRIPTION
## Summary
- Root cause (per issue #52's diagnosis): `.nss` has `filter: drop-shadow(...)`, forcing Chromium to rasterize the subtree into an integer-snapped compositing layer. The nested rotating `<svg>` (`nsRotate` animation) computes its transform origin in unsnapped space, so on fractional-DPR displays (Windows 125%/150% scaling) the origin flips between neighboring snapped pixels each frame, causing the wobble. Not reproducible on macOS/Safari because DPR is always exactly 1 or 2 there.
- Fix: give the rotating `svg` its own stable compositing layer and explicit center origin (`transform-origin: 50% 50%; will-change: transform; backface-visibility: hidden;`), decoupling it from the filtered ancestor's snapped bounds. Applied to both the default `nsRotate 2s` rule and the `prefers-reduced-motion` `nsRotate 6s` variant.
- No SVG markup, sizing, or drop-shadow changes — scoped purely to the rotating element's compositing behavior.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run test` — 47/47 passing, 100% coverage maintained
- [ ] Manual confirmation on Windows + Chrome with fractional display scaling (125%/150%) that the wobble is gone — can't verify from this environment, requesting the issue author confirm

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeUPS15p5Xg15AQPf9xkes